### PR TITLE
Update to PIT 1.4.0 (which needs Java 8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - openjdk6
+  - openjdk8
 
 script: cd guava-bundle && mvn install && cd ../pitest-bundles && mvn install && cd ../pitrunner && mvn install && cd ../pitclipse-plugin && mvn install

--- a/pitclipse-plugin/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
+++ b/pitclipse-plugin/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.ui,
  org.pitest.html-report-osgi;bundle-version="1.4.0",
  org.pitest.guava-shade-osgi;bundle-version="18.0.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Pitest.org
 Bundle-ClassPath: .
 Export-Package: org.pitest.pitclipse.core,

--- a/pitclipse-plugin/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
+++ b/pitclipse-plugin/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
@@ -13,9 +13,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.launching;bundle-version="3.6.101",
  org.eclipse.jdt.ui;bundle-version="3.8.2",
  org.pitest.pitrunner;bundle-version="1.1.6",
- org.pitest.osgi;bundle-version="1.1.9",
- org.pitest.command-line-osgi;bundle-version="1.1.9",
- org.pitest.html-report-osgi;bundle-version="1.1.9",
+ org.pitest.osgi;bundle-version="1.4.0",
+ org.pitest.command-line-osgi;bundle-version="1.4.0",
+ org.pitest.html-report-osgi;bundle-version="1.4.0",
  org.pitest.guava-shade-osgi;bundle-version="18.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/pitclipse-plugin/org.pitest.pitclipse.ui/META-INF/MANIFEST.MF
+++ b/pitclipse-plugin/org.pitest.pitclipse.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench.texteditor;bundle-version="3.6.1",
  org.eclipse.jface.text;bundle-version="3.6.1"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Pitest.org
 Bundle-ClassPath: .
 Export-Package: org.pitest.pitclipse.ui.extension.point

--- a/pitclipse-plugin/pitclipse-ui.tests/META-INF/MANIFEST.MF
+++ b/pitclipse-plugin/pitclipse-ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse UI Tests
 Bundle-SymbolicName: org.pitest.pitclipse-ui.tests;singleton:=true
 Bundle-Version: 1.1.6.201607050705
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/pitclipse-plugin/pom.xml
+++ b/pitclipse-plugin/pom.xml
@@ -25,7 +25,7 @@
     <maven.compiler.version>3.3</maven.compiler.version>
     <maven.jarsigner.version>1.4</maven.jarsigner.version>
     <mockito.version>1.9.5</mockito.version>
-    <pitest.version>1.1.9</pitest.version>
+    <pitest.version>1.4.0</pitest.version>
     <pitrunner.version>${project.version}</pitrunner.version>
     <tycho.version>0.22.0</tycho.version>
   </properties>

--- a/pitest-bundles/pitest-command-line-osgi/pom.xml
+++ b/pitest-bundles/pitest-command-line-osgi/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <artifactId>pitest-bundles</artifactId>
     <groupId>org.pitest</groupId>
-    <version>1.1.9</version>
+    <version>1.4.0</version>
   </parent>
   <artifactId>pitest-command-line-osgi</artifactId>
   <name>pitest-command-line-osgi</name>
   <packaging>bundle</packaging>
-  <version>1.1.9</version>
+  <version>1.4.0</version>
   <dependencies>
     <dependency>
       <groupId>org.pitest</groupId>

--- a/pitest-bundles/pitest-html-report-osgi/pom.xml
+++ b/pitest-bundles/pitest-html-report-osgi/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <artifactId>pitest-bundles</artifactId>
     <groupId>org.pitest</groupId>
-    <version>1.1.9</version>
+    <version>1.4.0</version>
   </parent>
   <artifactId>pitest-html-report-osgi</artifactId>
   <name>pitest-html-report-osgi</name>
   <packaging>bundle</packaging>
-  <version>1.1.9</version>
+  <version>1.4.0</version>
   <dependencies>
     <dependency>
       <groupId>org.pitest</groupId>

--- a/pitest-bundles/pitest-osgi/pom.xml
+++ b/pitest-bundles/pitest-osgi/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <artifactId>pitest-bundles</artifactId>
     <groupId>org.pitest</groupId>
-    <version>1.1.9</version>
+    <version>1.4.0</version>
   </parent>
   <artifactId>pitest-osgi</artifactId>
   <name>pitest-osgi</name>
   <packaging>bundle</packaging>
-  <version>1.1.9</version>
+  <version>1.4.0</version>
   <dependencies>
   	<dependency>
       <groupId>org.pitest</groupId>

--- a/pitest-bundles/pom.xml
+++ b/pitest-bundles/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>pitest-bundles</artifactId>
   <name>pitest-bundles</name>
   <packaging>pom</packaging>
-  <version>1.1.9</version>
+  <version>1.4.0</version>
   <organization>
     <name>Pitest.org</name>
     <url>http://pitest.org/</url>
@@ -17,7 +17,7 @@
     <felix.version>2.5.3</felix.version>
     <maven.compiler.version>3.3</maven.compiler.version>
     <maven.jarsigner.version>1.4</maven.jarsigner.version>
-    <pitest.version>1.1.9</pitest.version>
+    <pitest.version>1.4.0</pitest.version>
     <jarsigner.version>1.4</jarsigner.version>
   </properties>
   <dependencyManagement>

--- a/pitrunner/pom.xml
+++ b/pitrunner/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.version>3.3</maven.compiler.version>
     <maven.jarsigner.version>1.4</maven.jarsigner.version>
     <mockito.version>1.9.5</mockito.version>
-    <pitest.version>1.1.9</pitest.version>
+    <pitest.version>1.4.0</pitest.version>
     <tycho.version>0.15.0</tycho.version>
     <commons.version>3.1</commons.version>
   </properties>

--- a/pitrunner/pom.xml
+++ b/pitrunner/pom.xml
@@ -102,8 +102,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.version}</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
       </plugins>

--- a/pitrunner/src/main/java/org/pitest/pitclipse/pitrunner/results/mutations/PitclipseMutationsResultListener.java
+++ b/pitrunner/src/main/java/org/pitest/pitclipse/pitrunner/results/mutations/PitclipseMutationsResultListener.java
@@ -33,12 +33,7 @@ public class PitclipseMutationsResultListener implements MutationResultListener 
 			MutationDetails details = result.getDetails();
 			final Mutation mutation = OBJECT_FACTORY.createMutationsMutation();
 			mutation.setIndex(BigInteger.valueOf(details.getFirstIndex()));
-			result.getKillingTest().forEach(new SideEffect1<String>() {
-				@Override
-				public void apply(String killingTest) {
-					mutation.setKillingTest(killingTest);
-				}
-			});
+			result.getKillingTest().ifPresent((String killingTest) -> mutation.setKillingTest(killingTest));
 			mutation.setLineNumber(BigInteger.valueOf(details.getLineNumber()));
 			mutation.setMutatedClass(details.getClassName().asJavaName());
 			mutation.setMutatedMethod(details.getMethod().name());

--- a/pitrunner/src/test/java/org/pitest/pitclipse/pitrunner/results/mutations/PitclipseMutationsResultListenerTest.java
+++ b/pitrunner/src/test/java/org/pitest/pitclipse/pitrunner/results/mutations/PitclipseMutationsResultListenerTest.java
@@ -32,6 +32,7 @@ import org.pitest.mutationtest.engine.Location;
 import org.pitest.mutationtest.engine.MethodName;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.mutationtest.engine.PoisonStatus;
 import org.pitest.pitclipse.example.Foo;
 import org.pitest.pitclipse.pitrunner.results.DetectionStatus;
 import org.pitest.pitclipse.pitrunner.results.Mutations;
@@ -75,7 +76,7 @@ class ListenerTestFixture {
 		Location location = new Location(ClassName.fromClass(Foo.class), MethodName.fromString("doFoo"), "doFoo");
 		MutationIdentifier id = new MutationIdentifier(location, 1, "SomeMutator");
 		MutationDetails md = new MutationDetails(id, "org/pitest/pitclipse/example/Foo.java", TEST_FACTORY.aString(),
-				20, TEST_FACTORY.aRandomInt(), TEST_FACTORY.aRandomBoolean(), TEST_FACTORY.aRandomBoolean());
+				20, TEST_FACTORY.aRandomInt(), TEST_FACTORY.aRandomBoolean(), TEST_FACTORY.aRandomBoolean() ? PoisonStatus.MAY_POISON_JVM : PoisonStatus.NORMAL);
 		MutationStatusTestPair status = new MutationStatusTestPair(TEST_FACTORY.aRandomInt(),
 				org.pitest.mutationtest.DetectionStatus.KILLED, "org.pitest.pitclipse.example.ExampleTest");
 		MutationResult mutation = new MutationResult(md, status);

--- a/pitrunner/src/test/java/org/pitest/pitclipse/pitrunner/results/summary/SummaryResultListenerTestData.java
+++ b/pitrunner/src/test/java/org/pitest/pitclipse/pitrunner/results/summary/SummaryResultListenerTestData.java
@@ -27,6 +27,7 @@ import org.pitest.mutationtest.engine.Location;
 import org.pitest.mutationtest.engine.MethodName;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.mutationtest.engine.PoisonStatus;
 import org.pitest.pitclipse.example.Foo;
 import org.pitest.pitclipse.pitrunner.results.summary.SummaryResultListenerTestSugar.SummaryResultWrapper;
 import org.pitest.pitclipse.reloc.guava.base.Function;
@@ -63,7 +64,7 @@ class SummaryResultListenerTestData {
 		Location location = new Location(ClassName.fromClass(Foo.class), MethodName.fromString("doFoo"), "doFoo");
 		MutationIdentifier id = new MutationIdentifier(location, 1, "SomeMutator");
 		MutationDetails md = new MutationDetails(id, "org/pitest/pitclipse/example/Foo.java", TEST_FACTORY.aString(),
-				9, TEST_FACTORY.aRandomInt(), TEST_FACTORY.aRandomBoolean(), TEST_FACTORY.aRandomBoolean());
+				9, TEST_FACTORY.aRandomInt(), TEST_FACTORY.aRandomBoolean(), TEST_FACTORY.aRandomBoolean() ? PoisonStatus.MAY_POISON_JVM : PoisonStatus.NORMAL);
 		MutationStatusTestPair status = new MutationStatusTestPair(TEST_FACTORY.aRandomInt(), detectionStatus,
 				"org.pitest.pitclipse.example.ExampleTest");
 		MutationResult mutation = new MutationResult(md, status);


### PR DESCRIPTION
This pull request updates the dependencies to PIT 1.4.0 (the latest version at the time of writing) and fixes the ensuing compile errors. To be able to run the build, I had to update the required Java version to Java 8. Some minor adjustments to the codebase were needed where the interface of PIT changed.

I have not tested the changes in Eclipse, only through the Travis build.