### PR TITLE
Prevent UI tests from failing randomly (#81)

### DIFF
--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/FileMenu.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/FileMenu.java
@@ -42,10 +42,6 @@ public class FileMenu {
     }
 
     public void createClass(String packageName, String className) {
-//        bot.menu(FILE)
-//           .menu(NEW)
-//           .menu(CLASS)
-//           .click();
         bot.tree()
            .contextMenu()
            .menu(NEW)

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/NewClassWizard.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/NewClassWizard.java
@@ -17,6 +17,7 @@
 package org.pitest.pitclipse.ui.behaviours.pageobjects;
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 
 public class NewClassWizard {
@@ -33,6 +34,9 @@ public class NewClassWizard {
         bot.textWithLabel("Package:").setText(packageName);
         bot.textWithLabel("Name:").setText(className);
         bot.button("Finish").click();
+        
+        // Ensure the class is fully created before moving on
+        bot.waitUntil(Conditions.shellCloses(shell));
     }
 
 }

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PackageExplorer.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PackageExplorer.java
@@ -23,6 +23,7 @@ import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.junit.Assert.fail;
@@ -105,7 +106,14 @@ public class PackageExplorer {
     public void selectClass(String className, String packageName, String projectName) {
         SWTBotTreeItem project = getProject(projectName);
         SWTBotTreeItem pkg = selectAndExpand(getPackageFromProject(project, packageName));
-        selectAndExpand(getClassFromPackage(pkg, className));
+        SWTBotTreeItem classItem = getClassFromPackage(pkg, className);
+        
+        if (classItem == null) {
+            throw new NoSuchElementException("class " + className + 
+                                             " not found in package " + packageName + 
+                                             " of project " + projectName);
+        }
+        selectAndExpand(classItem);
     }
 
     public boolean doesClassExistInProject(String className, String packageName, String projectName) {
@@ -116,7 +124,14 @@ public class PackageExplorer {
 
     public void openClass(ClassContext context) {
         SWTBotTreeItem pkg = selectAndExpand(getPackage(context));
-        SWTBotTreeItem clazz = selectAndExpand(getClassFromPackage(pkg, context.getClassName()));
+        SWTBotTreeItem classItem = getClassFromPackage(pkg, context.getClassName());
+        
+        if (classItem == null) {
+            throw new NoSuchElementException("class " + context.getClassName() + 
+                                             " not found in package " + context.getPackageName() + 
+                                             " of project " + context.getProjectName());
+        }
+        SWTBotTreeItem clazz = selectAndExpand(classItem);
         clazz.doubleClick();
     }
 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunMenu.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunMenu.java
@@ -18,6 +18,7 @@ package org.pitest.pitclipse.ui.behaviours.pageobjects;
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.pitest.pitclipse.runner.PitOptions;
 import org.pitest.pitclipse.ui.swtbot.PitOptionsNotifier;
 import org.pitest.pitclipse.ui.swtbot.SWTBotMenuHelper;
@@ -46,12 +47,19 @@ public class RunMenu {
 
     public void runPit() {
         SWTBotMenuHelper menuHelper = new SWTBotMenuHelper();
-        menuHelper.findMenu(bot.menu(RUN).menu(RUN_AS), PIT_MUTATION_TEST)
+        SWTBotMenu runAsMenu = bot.menu(RUN)
+                                  .menu(RUN_AS);
+        menuHelper.findMenu(runAsMenu, PIT_MUTATION_TEST)
                   .click();
         try {
-            bot.shell("Select a Test Configuration").bot().button("OK").click();
+            bot.shell("Select a Test Configuration")
+               .bot()
+               .button("OK")
+               .click();
         } catch (WidgetNotFoundException e) {
-            // the dialog has not opened: it is likely the first time Pit is launched
+            // The 'Select a Test Configuration' dialog only appears when Pit has been launched
+            // at least once. If it is not found then PIT has been launched directly during the 
+            // click on 'Run As > PIT Mutation Test' so everything's alright.
         }
     }
 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/SourceMenu.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/SourceMenu.java
@@ -31,11 +31,15 @@ public class SourceMenu {
     }
 
     public void organizeImports() {
-        bot.menu(SOURCE).menu(ORGANIZE_IMPORTS).click();
+        bot.menu(SOURCE)
+           .menu(ORGANIZE_IMPORTS)
+           .click();
     }
 
     public void format() {
-        bot.menu(SOURCE).menu(FORMAT).click();
+        bot.menu(SOURCE)
+           .menu(FORMAT)
+           .click();
     }
 
 }

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/SwtBotTreeHelper.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/SwtBotTreeHelper.java
@@ -21,7 +21,9 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 public class SwtBotTreeHelper {
 
     public static SWTBotTreeItem selectAndExpand(SWTBotTreeItem item) {
-        return expand(item.select().click());
+        SWTBotTreeItem selectedItem = item.select()
+                                          .click();
+        return expand(selectedItem);
     }
 
     public static SWTBotTreeItem expand(SWTBotTreeItem item) {

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -1,0 +1,25 @@
+package org.pitest.pitclipse.ui.behaviours.pageobjects;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+
+class ViewOpenedCondition extends DefaultCondition {
+    
+    private SWTWorkbenchBot bot;
+    private String viewTitle;
+
+    public ViewOpenedCondition(SWTWorkbenchBot bot, String viewTitle) {
+        this.bot = bot;
+        this.viewTitle = viewTitle;
+    }
+    
+    @Override
+    public boolean test() throws Exception {
+        return bot.viewByTitle(viewTitle) != null;
+    }
+    
+    @Override
+    public String getFailureMessage() {
+        return "The view '" + viewTitle + "' did not open";
+    }
+}

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/WindowsMenu.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/WindowsMenu.java
@@ -43,7 +43,11 @@ public class WindowsMenu {
     }
 
     public void openJavaPerspective() {
-        bot.menu(WINDOWS).menu("Perspective").menu(OPEN_PERSPECTIVES).menu(OTHER).click();
+        bot.menu(WINDOWS)
+           .menu("Perspective")
+           .menu(OPEN_PERSPECTIVES)
+           .menu(OTHER)
+           .click();
         perspectiveSelector.selectPerspective("Java");
 //        for (IPerspectiveDescriptor descriptor : PlatformUI.getWorkbench().getPerspectiveRegistry().getPerspectives()) {
 //            System.out.println(descriptor.getLabel() + " -- " + descriptor.getId());


### PR DESCRIPTION
Addresses issue #81 _UI tests randomly fail_

Run a dozen of builds on both Travis CI and my own computer; none of them failed. Hence, it seems that issue is fixed. However, even if the build is way more stable now, some unexpected failures may still show up. I'll wait a bit before merging the PR. 

Here are the new improvements:

- wait for the "New Class" wizard to close before moving on,
- when testing the _PIT Mutations_ view make sure that the event triggered by double-clicking on a mutation has been fully processed before checking its effects
- try to fail fast when a compilation error is detected instead of waiting Travis CI to kill the build after 10 min