### PR TITLE
#79 Create a Maven profile to publish p2 to Bintray 

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
- 
+
 <extensions>
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You will need [Maven 3.x](https://maven.apache.org/download.cgi), [Java 8 JDK](h
 First of all, clone the repository:
 
 ```
-git clone https://github.com/philglover/pitclipse.git
+git clone https://github.com/pitest/pitclipse.git
 ```
 
 Then:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pitclipse
 
-[![Build Status](https://travis-ci.com/pitest/pitclipse.svg?branch=master)](https://travis-ci.com/pitest/pitclipse) [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=sqale_index)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=coverage)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=ncloc)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse)
+[![Build Status](https://travis-ci.com/pitest/pitclipse.svg?branch=master)](https://travis-ci.com/pitest/pitclipse) [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=sqale_index)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=coverage)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=org.pitest%3Aorg.pitest.pitclipse&metric=ncloc)](https://sonarcloud.io/dashboard?id=org.pitest%3Aorg.pitest.pitclipse) [ ![Download](https://api.bintray.com/packages/kazejiyu/Pitclipse/releases/images/download.svg) ](https://bintray.com/kazejiyu/Pitclipse/releases/_latestVersion)
 
 Provides support for [PIT (Pitest)](http://pitest.org) within the Eclipse IDE. Allows to compute the mutation coverage of your code and shows the result within dedicated views.
 
@@ -37,10 +37,12 @@ Drag the following button to your running Eclipse workspace to start the install
   <a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1426461" class="drag" title="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client"><img typeof="foaf:Image" class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.png" alt="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client" /></a>
 </div>
 
-### From the update site
-Alternatively, the plug-in can also be installed from the following update site:
+> **/!\\** Not up-to-date at the moment, please use the update site below
 
-- [http://eclipse.pitest.org/release/](http://eclipse.pitest.org/release/)
+### From the update site
+Alternatively, the plug-in can also be installed from the following (temporary) update site:
+
+- [https://dl.bintray.com/kazejiyu/Pitclipse/updates/](https://dl.bintray.com/kazejiyu/Pitclipse/updates/)
 
 To use it from Eclipse IDE, click on `Help` > `Install new software...` and then paste the above URL.
 

--- a/bundles/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Activator: org.pitest.pitclipse.core.PitCoreActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.11.2,4.0.0)",
  org.pitest.pitclipse.runner;bundle-version="[2.0.0,3.0.0)",
- com.google.guava;bundle-version="21.0.0",
  org.pitest;bundle-version="1.4.6",
  org.eclipse.core.resources;bundle-version="[3.10.1,4.0.0)",
  org.eclipse.ui;bundle-version="[3.107.0,4.0.0)"
@@ -21,5 +20,7 @@ Export-Package: org.pitest.pitclipse.core,
  org.pitest.pitclipse.core.launch,
  org.pitest.pitclipse.core.preferences
 Automatic-Module-Name: org.pitest.pitclipse.core
-Import-Package: org.eclipse.jface.preference,
+Import-Package: com.google.common.collect;version="21.0.0",
+ com.google.common.io;version="21.0.0",
+ org.eclipse.jface.preference,
  org.eclipse.ui.preferences

--- a/bundles/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Core
 Bundle-SymbolicName: org.pitest.pitclipse.core;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Activator: org.pitest.pitclipse.core.PitCoreActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.11.2,4.0.0)",

--- a/bundles/org.pitest.pitclipse.launch.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.launch.ui/META-INF/MANIFEST.MF
@@ -15,6 +15,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.11.2,4.0.0)",
  org.pitest.pitclipse.launch,
  org.eclipse.jface;bundle-version="[3.11.1,4.0.0)",
- com.google.guava;bundle-version="[21.0.0,22.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.107.1,4.0.0)",
  org.eclipse.jdt.debug.ui;bundle-version="[3.7.101,4.0.0)"
+Import-Package: com.google.common.collect;version="21.0.0"

--- a/bundles/org.pitest.pitclipse.launch.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.launch.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Launch Configurations UI
 Bundle-SymbolicName: org.pitest.pitclipse.launch.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.launch.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.pitest.pitclipse.launch/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.launch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Launch Configurations
 Bundle-SymbolicName: org.pitest.pitclipse.launch;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.launch
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.pitest.pitclipse.launch/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.launch/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.launch
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.google.guava;bundle-version="[21.0.0,22.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.8.0,4.0.0)",
  org.pitest.pitclipse.core,
@@ -15,3 +14,5 @@ Require-Bundle: com.google.guava;bundle-version="[21.0.0,22.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.11.2,4.0.0)"
 Export-Package: org.pitest.pitclipse.launch,
  org.pitest.pitclipse.launch.config
+Import-Package: com.google.common.base;version="21.0.0",
+ com.google.common.collect;version="21.0.0"

--- a/bundles/org.pitest.pitclipse.listeners/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.listeners/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse's Pitest Listeners
 Bundle-SymbolicName: org.pitest.pitclipse.listeners
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Fragment-Host: org.pitest;bundle-version="1.4.6"
 Automatic-Module-Name: org.pitest.pitclipse.listeners
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.pitest.pitclipse.preferences.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.preferences.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Preferences UI
 Bundle-SymbolicName: org.pitest.pitclipse.preferences.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.preferences.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.pitest.pitclipse.runner/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.runner/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Runner
 Bundle-SymbolicName: org.pitest.pitclipse.runner
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.runner
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.pitest.pitclipse.runner/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.runner/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Automatic-Module-Name: org.pitest.pitclipse.runner
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.google.guava;bundle-version="[21.0.0,22.0.0)",
- org.pitest;bundle-version="1.4.6"
+Require-Bundle: org.pitest;bundle-version="1.4.6"
 Export-Package: org.pitest.pitclipse.runner,
  org.pitest.pitclipse.runner.client,
  org.pitest.pitclipse.runner.config,
@@ -18,3 +17,7 @@ Export-Package: org.pitest.pitclipse.runner,
  org.pitest.pitclipse.runner.results.summary,
  org.pitest.pitclipse.runner.server,
  org.pitest.pitclipse.runner.service
+Import-Package: com.google.common.annotations;version="21.0.0",
+ com.google.common.base;version="21.0.0",
+ com.google.common.collect;version="21.0.0",
+ com.google.common.io;version="21.0.0"

--- a/bundles/org.pitest.pitclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse UI
 Bundle-SymbolicName: org.pitest.pitclipse.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.1,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.10.1,4.0.0)",

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.bundles</artifactId>

--- a/features/org.pitest.feature/feature.xml
+++ b/features/org.pitest.feature/feature.xml
@@ -198,7 +198,7 @@
       same &quot;printed page&quot; as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2010 Henry Coles
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.

--- a/features/org.pitest.pitclipse.core.feature/feature.xml
+++ b/features/org.pitest.pitclipse.core.feature/feature.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.pitest.pitclipse.core.feature"
-      label="Pitest Core"
+      label="Pitclipse Core"
       version="2.0.0"
       provider-name="Pitest.org">
 
-   <description url="https://github.com/philglover/pitclipse">
+   <description url="https://github.com/pitest/pitclipse">
       Eclipse IDE integration of Pitest (PIT), a state of the art mutation system for the JVM.
    </description>
 
@@ -218,20 +218,21 @@
    </license>
 
    <url>
-      <update label="Pitclipse" url="http://eclipse.pitest.org/release/"/>
+      <update label="Pitclipse" url="https://dl.bintray.com/kazejiyu/Pitclipse/updates/"/>
    </url>
 
    <requires>
-      <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
       <import plugin="org.eclipse.core.runtime" version="3.11.1" match="compatible"/>
-      <import plugin="org.eclipse.core.resources" version="3.10.1" match="compatible"/>
       <import plugin="org.eclipse.jdt.core" version="3.11.2" match="compatible"/>
-      <import plugin="org.eclipse.debug.ui" version="3.11.101" match="compatible"/>
-      <import plugin="org.eclipse.jdt.debug.ui" version="3.7.101" match="compatible"/>
-      <import plugin="org.eclipse.jdt.launching" version="3.8.0" match="compatible"/>
-      <import plugin="org.eclipse.jdt.ui" version="3.11.2" match="compatible"/>
-      <import plugin="org.pitest" version="1.4.6" match="compatible"/>
       <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources" version="3.10.1" match="compatible"/>
+      <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
+      <import plugin="org.eclipse.jdt.launching" version="3.8.0" match="compatible"/>
+      <import plugin="org.pitest.pitclipse.runner" version="2.0.0" match="compatible"/>
+      <import plugin="org.pitest" version="1.4.6" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jface"/>
+      <import plugin="org.eclipse.ui.workbench"/>
+      <import plugin="org.eclipse.debug.core" version="3.10.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/features/org.pitest.pitclipse.core.feature/feature.xml
+++ b/features/org.pitest.pitclipse.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.pitest.pitclipse.core.feature"
       label="Pitest Core"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="Pitest.org">
 
    <description url="https://github.com/philglover/pitclipse">

--- a/features/org.pitest.pitclipse.ui.feature/feature.xml
+++ b/features/org.pitest.pitclipse.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.pitest.pitclipse.ui.feature"
       label="Pitest UI"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="Pitest.org">
 
    <description url="https://github.com/philglover/pitclipse">

--- a/features/org.pitest.pitclipse.ui.feature/feature.xml
+++ b/features/org.pitest.pitclipse.ui.feature/feature.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.pitest.pitclipse.ui.feature"
-      label="Pitest UI"
+      label="Pitclipse UI"
       version="2.0.0"
       provider-name="Pitest.org">
 
-   <description url="https://github.com/philglover/pitclipse">
+   <description url="https://github.com/pitest/pitclipse">
       UI integration of Pitest (PIT), a state of the art mutation system for the JVM.
 Provides views and contextual actions to search the code for mutations and show vulnerabilities.
    </description>
@@ -215,7 +215,7 @@ Provides views and contextual actions to search the code for mutations and show 
    </license>
 
    <url>
-      <update label="Pitclipse" url="http://eclipse.pitest.org/release/"/>
+      <update label="Pitclipse" url="https://dl.bintray.com/kazejiyu/Pitclipse/updates/"/>
    </url>
 
    <requires>
@@ -229,7 +229,13 @@ Provides views and contextual actions to search the code for mutations and show 
       <import plugin="org.eclipse.ui.workbench.texteditor" version="3.9.100" match="compatible"/>
       <import plugin="org.eclipse.jface.text" version="3.10.0" match="compatible"/>
       <import plugin="org.pitest.pitclipse.runner"/>
-      <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>
+      <import plugin="com.google.guava" version="21.0.0" match="compatible"/>
+      <import plugin="org.eclipse.debug.ui" version="3.11.101" match="compatible"/>
+      <import plugin="org.eclipse.jdt.launching" version="3.8.0" match="compatible"/>
+      <import plugin="org.pitest.pitclipse.launch"/>
+      <import plugin="org.eclipse.jface" version="3.11.1" match="compatible"/>
+      <import plugin="org.eclipse.ui.workbench" version="3.107.1" match="compatible"/>
+      <import plugin="org.eclipse.jdt.debug.ui" version="3.7.101" match="compatible"/>
    </requires>
 
    <plugin

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.features</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
 
 		* Change project's version:
 			mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=major.minor.bug
+
+		* Publish current version to Bintray (caution: version *must* be legacy, e.g. x.y.z, no snapshot):
+			mvn clean verify -P release-composite -D skipTests
+		  Also note that it requires my (@echebbi) Bintray credentials.
 	-->
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.pitest</groupId>
 	<artifactId>org.pitest.pitclipse</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<packaging>pom</packaging>
 
 	<name>Pitclipse</name>
@@ -74,7 +74,7 @@
 						<artifact>
 							<groupId>org.pitest</groupId>
 							<artifactId>org.pitest.pitclipse.target</artifactId>
-							<version>2.0.0-SNAPSHOT</version>
+							<version>2.0.0</version>
 						</artifact>
 					</target>
 					<environments>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
 	<properties>
 		<!-- DEPENDENCIES -->
-		<tycho-version>1.4.0</tycho-version>
+		<tycho-version>1.5.0-SNAPSHOT</tycho-version>
 		<jacoco-version>0.8.1</jacoco-version>
 
 		<!-- SONARQUBE -->
@@ -53,6 +53,13 @@
 			mvn clean verify -P release-composite -D skipTests
 		  Also note that it requires my (@echebbi) Bintray credentials.
 	-->
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>tycho-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<build>
 		<plugins>

--- a/releng/org.pitest.pitclipse.p2/bintray.ant
+++ b/releng/org.pitest.pitclipse.p2/bintray.ant
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="Handle p2 composite metadata from Bintray" basedir=".">
+
+	<!--
+	These must be set from outside
+	<property name="bintray.user" value="" />
+	<property name="bintray.apikey" value="" />
+	<property name="bintray.repo" value="" />
+	<property name="bintray.package" value="" />
+	<property name="bintray.releases.path" value="" />
+	<property name="bintray.composite.path" value="" />
+	<property name="bintray.zip.path" value="" />
+	-->
+
+	<property name="bintray.url" value="https://dl.bintray.com/${bintray.owner}/${bintray.repo}" />
+	<condition property="bintray.package.version" value="${unqualifiedVersion}" else="${unqualifiedVersion}.${buildQualifier}">
+		<or>
+			<not>
+				<isset property="buildQualifier"/>
+			</not>
+			<equals arg1="" arg2="${buildQualifier}"/>
+		</or>
+	</condition>
+	<property name="bintray.releases.target.path" value="${bintray.releases.path}/${bintray.package.version}" />
+
+	<property name="main.composite.url" value="${bintray.url}/${bintray.composite.path}" />
+	<property name="target" value="target" />
+	<property name="composite.repository.directory" value="composite-child" />
+	<property name="main.composite.repository.directory" value="composite-main" />
+
+	<property name="compositeArtifacts" value="compositeArtifacts.xml" />
+	<property name="compositeContent" value="compositeContent.xml" />
+
+	<property name="local.p2.repository" value="target/repository" />
+
+	<target name="getMajorMinorVersion">
+		<script language="javascript">
+			<![CDATA[
+	                // getting the value
+	                buildnumber = project.getProperty("unqualifiedVersion");
+	                index = buildnumber.lastIndexOf(".");
+	                counter = buildnumber.substring(0, index);
+	    			project.setProperty("majorMinorVersion",counter);
+	            ]]>
+		</script>
+	</target>
+
+	<!-- Take from the remote URL the possible existing metadata -->
+	<target name="get-composite-metadata" depends="getMajorMinorVersion" >
+		<get-metadata url="${main.composite.url}" dest="${target}/${main.composite.repository.directory}" />
+		<get-metadata url="${main.composite.url}/${majorMinorVersion}" dest="${target}/${composite.repository.directory}" />
+		<antcall target="preprocess-metadata" />
+	</target>
+
+	<macrodef name="get-metadata" description="Retrieve the p2 composite metadata">
+		<attribute name="url" />
+		<attribute name="dest" />
+		<sequential>
+			<echo message="Creating directory @{dest}..." />
+			<mkdir dir="@{dest}" />
+			<get-file file="${compositeArtifacts}" url="@{url}" dest="@{dest}" />
+			<get-file file="${compositeContent}" url="@{url}" dest="@{dest}" />
+		</sequential>
+	</macrodef>
+
+	<macrodef name="get-file" description="Use Ant Get task the file">
+		<attribute name="file" />
+		<attribute name="url" />
+		<attribute name="dest" />
+		<sequential>
+			<!-- If the remote file does not exist then fail gracefully -->
+			<echo message="Getting @{file} from @{url} into @{dest}..." />
+			<get dest="@{dest}" ignoreerrors="true">
+				<url url="@{url}/@{file}" />
+			</get>
+		</sequential>
+	</macrodef>
+
+	<!-- p2.atomic.composite.loading must be set to false otherwise we won't be able
+		to add a child to the composite repository without having all the children available -->
+	<target name="preprocess-metadata" description="Preprocess p2 composite metadata">
+		<replaceregexp byline="true">
+			<regexp pattern="property name='p2.atomic.composite.loading' value='true'" />
+			<substitution expression="property name='p2.atomic.composite.loading' value='false'" />
+			<fileset dir="${target}">
+				<include name="${composite.repository.directory}/*.xml" />
+				<include name="${main.composite.repository.directory}/*.xml" />
+			</fileset>
+		</replaceregexp>
+	</target>
+
+	<!-- p2.atomic.composite.loading must be set to true
+		see https://bugs.eclipse.org/bugs/show_bug.cgi?id=356561 -->
+	<target name="postprocess-metadata" description="Preprocess p2 composite metadata">
+		<replaceregexp byline="true">
+			<regexp pattern="property name='p2.atomic.composite.loading' value='false'" />
+			<substitution expression="property name='p2.atomic.composite.loading' value='true'" />
+			<fileset dir="${target}">
+				<include name="${composite.repository.directory}/*.xml" />
+				<include name="${main.composite.repository.directory}/*.xml" />
+			</fileset>
+		</replaceregexp>
+	</target>
+
+	<target name="push-to-bintray" >
+		<antcall target="postprocess-metadata" />
+		<antcall target="push-p2-repo-to-bintray" />
+		<antcall target="push-p2-repo-zipped-to-bintray" />
+		<antcall target="push-composite-to-bintray" />
+		<antcall target="push-main-composite-to-bintray" />
+	</target>
+
+	<target name="push-p2-repo-to-bintray">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${local.p2.repository}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${local.p2.repository}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.releases.target.path}/*;bt_package=${bintray.package};bt_version=${bintray.package.version};publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-p2-repo-zipped-to-bintray">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}" includes="*.zip" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.zip.path}/*;bt_package=${bintray.package};bt_version=${bintray.package.version};publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-composite-to-bintray" depends="getMajorMinorVersion" >
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}/${composite.repository.directory}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/${composite.repository.directory}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.composite.path}/${majorMinorVersion}/*;publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-main-composite-to-bintray" >
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}/${main.composite.repository.directory}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/${main.composite.repository.directory}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.composite.path}/*;publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+</project>

--- a/releng/org.pitest.pitclipse.p2/category.xml
+++ b/releng/org.pitest.pitclipse.p2/category.xml
@@ -14,4 +14,5 @@
          Eclipse support for Pitest (PIT), a state of the art mutation testing system
       </description>
    </category-def>
+   <repository-reference location="https://download.eclipse.org/tools/orbit/downloads/drops/R20170818183741/repository" enabled="true" />
 </site>

--- a/releng/org.pitest.pitclipse.p2/category.xml
+++ b/releng/org.pitest.pitclipse.p2/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.pitest.pitclipse.core.feature_2.0.0.qualifier.jar" id="org.pitest.pitclipse.core.feature" version="2.0.0.qualifier">
+   <feature url="features/org.pitest.pitclipse.core.feature_2.0.0.jar" id="org.pitest.pitclipse.core.feature" version="2.0.0">
       <category name="org.pitest.pitclipse"/>
    </feature>
-   <feature url="features/org.pitest.pitclipse.ui.feature_2.0.0.qualifier.jar" id="org.pitest.pitclipse.ui.feature" version="2.0.0.qualifier">
+   <feature url="features/org.pitest.pitclipse.ui.feature_2.0.0.jar" id="org.pitest.pitclipse.ui.feature" version="2.0.0">
       <category name="org.pitest.pitclipse"/>
    </feature>
    <feature url="features/org.pitest.feature_1.4.6.jar" id="org.pitest.feature" version="1.4.6">

--- a/releng/org.pitest.pitclipse.p2/packaging-p2composite.ant
+++ b/releng/org.pitest.pitclipse.p2/packaging-p2composite.ant
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<project name="project">
+
+	<target name="getMajorMinorVersion">
+		<script language="javascript">
+			<![CDATA[
+	                // getting the value
+	                buildnumber = project.getProperty("unqualifiedVersion");
+	                index = buildnumber.lastIndexOf(".");
+	                counter = buildnumber.substring(0, index);
+	    			project.setProperty("majorMinorVersion",counter);
+	            ]]>
+		</script>
+	</target>
+
+	<target name="test_getMajorMinor" depends="getMajorMinorVersion">
+		<echo message="majorMinorVersion: ${majorMinorVersion}" />
+	</target>
+
+	<!--
+		site.label						The name/title/label of the created composite site
+		unqualifiedVersion 				The version without any qualifier replacement
+		buildQualifier					The build qualifier
+		child.repository.path.prefix	The path prefix to access the actual p2 repo from the
+										child repo, e.g., if child repo is in /updates/1.0 and
+										the p2 repo is in /releases/1.0.0.something then this property
+										should be "../../releases/"
+	-->
+	<target name="compute.child.repository.data" depends="getMajorMinorVersion">
+		<condition property="full.version" value="${unqualifiedVersion}" else="${unqualifiedVersion}.${buildQualifier}">
+			<or>
+				<not>
+					<isset property="buildQualifier"/>
+				</not>
+				<equals arg1="" arg2="${buildQualifier}"/>
+			</or>
+		</condition>
+
+		<property name="site.composite.name" value="${site.label} ${majorMinorVersion}" />
+		<property name="main.site.composite.name" value="${site.label} All Versions" />
+
+		<!-- composite.base.dir	The base directory for the local composite metadata,
+			e.g., from Maven, ${project.build.directory}
+		-->
+		<property name="composite.base.dir" value="target"/>
+
+		<property name="main.composite.repository.directory" location="${composite.base.dir}/composite-main" />
+		<property name="composite.repository.directory" location="${composite.base.dir}/composite-child" />
+
+		<property name="child.repository" value="${child.repository.path.prefix}${full.version}" />
+	</target>
+
+	<target name="p2.composite.add" depends="compute.child.repository.data">
+		<add.composite.repository.internal composite.repository.location="${main.composite.repository.directory}" composite.repository.name="${main.site.composite.name}" composite.repository.child="${majorMinorVersion}" />
+		<add.composite.repository.internal composite.repository.location="${composite.repository.directory}" composite.repository.name="${site.composite.name}" composite.repository.child="${child.repository}" />
+	</target>
+
+	<!-- = = = = = = = = = = = = = = = = =
+          macrodef: add.composite.repository.internal          
+         = = = = = = = = = = = = = = = = = -->
+	<macrodef name="add.composite.repository.internal">
+		<attribute name="composite.repository.location" />
+		<attribute name="composite.repository.name" />
+		<attribute name="composite.repository.child" />
+		<sequential>
+
+			<echo message=" " />
+			<echo message="Composite repository       : @{composite.repository.location}" />
+			<echo message="Composite name             : @{composite.repository.name}" />
+			<echo message="Adding child repository    : @{composite.repository.child}" />
+
+			<p2.composite.repository>
+				<repository compressed="false" location="@{composite.repository.location}" name="@{composite.repository.name}" />
+				<add>
+					<repository location="@{composite.repository.child}" />
+				</add>
+			</p2.composite.repository>
+
+			<echo file="@{composite.repository.location}/p2.index">version=1
+metadata.repository.factory.order=compositeContent.xml,\!
+artifact.repository.factory.order=compositeArtifacts.xml,\!
+</echo>
+
+		</sequential>
+	</macrodef>
+
+
+</project>

--- a/releng/org.pitest.pitclipse.p2/pom.xml
+++ b/releng/org.pitest.pitclipse.p2/pom.xml
@@ -13,4 +13,125 @@
 	<artifactId>org.pitest.pitclipse.p2</artifactId>
 	<packaging>eclipse-repository</packaging>
 
+	<properties>
+		<bintray.repo>Pitclipse</bintray.repo>
+		<!-- The name of Bintray repository's package for releases -->
+		<bintray.package>releases</bintray.package>
+		<!-- The label for the Composite sites -->
+		<site.label>Pitclipse</site.label>
+
+		<bintray.owner>${bintray.user}</bintray.owner>
+
+		<!-- Default values for remote directories -->
+		<bintray.releases.path>releases</bintray.releases.path>
+		<bintray.composite.path>updates</bintray.composite.path>
+		<bintray.zip.path>zipped</bintray.zip.path>
+		<!-- note that the following must be consistent with the path schema
+			used to publish child composite repositories and actual released p2 repositories -->
+		<child.repository.path.prefix>../../releases/</child.repository.path.prefix>
+	</properties>
+
+    <profiles>
+		<profile>
+			<!-- Activate this profile to release a legacy version (x.y.z) to Bintray -->
+			<id>release-composite</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.7</version>
+						<executions>
+							<execution>
+								<!-- Retrieve possibly existing remote composite metadata -->
+								<id>update-local-repository</id>
+								<phase>prepare-package</phase>
+								<configuration>
+									<target>
+										<ant antfile="${basedir}/bintray.ant" target="get-composite-metadata">
+										</ant>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+
+							<execution>
+								<!-- Deploy p2 repository, p2 composite updated metadata and zipped p2 repository -->
+								<id>deploy-repository</id>
+								<phase>verify</phase>
+								<configuration>
+									<target>
+										<ant antfile="${basedir}/bintray.ant" target="push-to-bintray">
+										</ant>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-eclipserun-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<!-- Update p2 composite metadata or create it -->
+							<!-- IMPORTANT: DO NOT split the arg line -->
+							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
+							<repositories>
+								<repository>
+									<id>mars</id>
+									<layout>p2</layout>
+									<url>http://download.eclipse.org/releases/mars</url>
+								</repository>
+							</repositories>
+							<dependencies>
+								<dependency>
+									<artifactId>org.eclipse.ant.core</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.apache.ant</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.repository.tools</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.core.feature</artifactId>
+									<type>eclipse-feature</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.extras.feature</artifactId>
+									<type>eclipse-feature</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.ds</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+							</dependencies>
+						</configuration>
+						<executions>
+							<execution>
+								<id>add-p2-composite-repository</id>
+								<phase>package</phase>
+								<goals>
+									<goal>eclipse-run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/releng/org.pitest.pitclipse.p2/pom.xml
+++ b/releng/org.pitest.pitclipse.p2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.releng</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.p2</artifactId>

--- a/releng/org.pitest.pitclipse.p2/removeFromBintray.sh
+++ b/releng/org.pitest.pitclipse.p2/removeFromBintray.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# remove p2 metadata artifacts from bintray remote path
+#Sample Usage: removeFromBintray.sh apikey remotePath
+BINTRAY_API_KEY=$1
+PATH_TO_REPOSITORY=$2
+
+BINTRAY_USER=lorenzobettini
+BINTRAY_REPO=p2-composite-example
+
+function main() {
+remove_p2_metadata
+}
+
+function remove_p2_metadata() {
+echo "${BINTRAY_USER}"
+echo "${BINTRAY_API_KEY}"
+echo "${BINTRAY_REPO}"
+echo "${PCK_NAME}"
+echo "${PCK_VERSION}"
+echo "${PATH_TO_REPOSITORY}"
+
+
+echo "Removing metadata content.jar..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/content.jar"
+echo ""
+echo "Removing metadata artifacts.jar..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/artifacts.jar"
+echo ""
+echo "Removing metadata compositeContent.xml..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/compositeContent.xml"
+echo ""
+echo "Removing metadata compositeArtifacts.xml..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/compositeArtifacts.xml"
+echo ""
+echo "Removing metadata p2.index..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/p2.index"
+echo ""
+
+}
+
+
+
+main "$@"

--- a/releng/org.pitest.pitclipse.target/pom.xml
+++ b/releng/org.pitest.pitclipse.target/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.releng</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.target</artifactId>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.releng</artifactId>

--- a/tests/io.cucumber/pom.xml
+++ b/tests/io.cucumber/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.tests</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>io.cucumber</artifactId>

--- a/tests/org.pitest.pitclipse.runner.tests/META-INF/MANIFEST.MF
+++ b/tests/org.pitest.pitclipse.runner.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse Runner Tests
 Bundle-SymbolicName: org.pitest.pitclipse.runner.tests
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Fragment-Host: org.pitest.pitclipse.runner;bundle-version="2.0.0"
 Automatic-Module-Name: org.pitest.pitclipse.runner.tests

--- a/tests/org.pitest.pitclipse.runner.tests/pom.xml
+++ b/tests/org.pitest.pitclipse.runner.tests/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.tests</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<build>

--- a/tests/org.pitest.pitclipse.tests.coverage.report/pom.xml
+++ b/tests/org.pitest.pitclipse.tests.coverage.report/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.tests</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
     <artifactId>org.pitest.pitclipse.tests.coverage.report</artifactId>
@@ -43,25 +43,25 @@
 		<dependency>
 			<groupId>org.pitest</groupId>
 			<artifactId>org.pitest.pitclipse.runner</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>2.0.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.pitest</groupId>
 			<artifactId>org.pitest.pitclipse.runner.tests</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>2.0.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.pitest</groupId>
 			<artifactId>org.pitest.pitclipse.ui</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>2.0.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.pitest</groupId>
 			<artifactId>org.pitest.pitclipse.ui.tests</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>2.0.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tests/org.pitest.pitclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.pitest.pitclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitclipse UI Tests
 Bundle-SymbolicName: org.pitest.pitclipse.ui.tests;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: Pitest.org
 Fragment-Host: org.pitest.pitclipse.ui;bundle-version="2.0.0"
 Automatic-Module-Name: org.pitest.pitclipse.ui.tests

--- a/tests/org.pitest.pitclipse.ui.tests/pom.xml
+++ b/tests/org.pitest.pitclipse.ui.tests/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse.tests</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>org.pitest.pitclipse</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<artifactId>org.pitest.pitclipse.tests</artifactId>


### PR DESCRIPTION
A composite update has been published at https://dl.bintray.com/kazejiyu/Pitclipse/updates/. It can be updated with `mvn verify -P release-composite`.

I tested the release on Mars 2 (Java package) and 2019-09 (Modeling package) releases, with JDK 1.8 and 12. Everything looks fine, but Pitest does not work with a Java project using Java 9 modules. This is likely because Pitclipse dynamically adds `PitRunner` to the project's classpath at runtime, which is ignored when the modulepath is taken into account.