### PR TITLE
Properly express dependencies between Pitclipse's features (fix #76)

### DIFF
--- a/features/org.pitest.pitclipse.core.feature/feature.xml
+++ b/features/org.pitest.pitclipse.core.feature/feature.xml
@@ -221,18 +221,20 @@
       <update label="Pitclipse" url="https://dl.bintray.com/kazejiyu/Pitclipse/updates/"/>
    </url>
 
+   <includes
+         id="org.pitest.feature"
+         version="0.0.0"/>
+
    <requires>
       <import plugin="org.eclipse.core.runtime" version="3.11.1" match="compatible"/>
       <import plugin="org.eclipse.jdt.core" version="3.11.2" match="compatible"/>
-      <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.10.1" match="compatible"/>
       <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
-      <import plugin="org.eclipse.jdt.launching" version="3.8.0" match="compatible"/>
-      <import plugin="org.pitest.pitclipse.runner" version="2.0.0" match="compatible"/>
-      <import plugin="org.pitest" version="1.4.6" match="greaterOrEqual"/>
+      <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface"/>
       <import plugin="org.eclipse.ui.workbench"/>
       <import plugin="org.eclipse.debug.core" version="3.10.0" match="compatible"/>
+      <import plugin="org.eclipse.jdt.launching" version="3.8.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/features/org.pitest.pitclipse.ui.feature/feature.xml
+++ b/features/org.pitest.pitclipse.ui.feature/feature.xml
@@ -218,6 +218,10 @@ Provides views and contextual actions to search the code for mutations and show 
       <update label="Pitclipse" url="https://dl.bintray.com/kazejiyu/Pitclipse/updates/"/>
    </url>
 
+   <includes
+         id="org.pitest.pitclipse.core.feature"
+         version="0.0.0"/>
+
    <requires>
       <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
       <import plugin="org.eclipse.core.runtime" version="3.11.1" match="compatible"/>


### PR DESCRIPTION
- Feature "Pitest" is now included into feature "Pitclipse Core"
- Feature "Pitclipse Core" is now included into feature "Pitclipse UI"

As a result, even if a user checks only the "Pitclipse UI" feature the three of them are installed anyway. That prevents unexpected installation issues.