### PR TITLE
don't run sonar:sonar on forked repositories

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,7 +4,8 @@
 # Indeed, that means that the build is performed on a branch of the
 # pitest/pitclipse repository (or an internal PR) and that Travis CI allows us to use
 # encrypted variables (e.g. Sonar's token)
-if [ "${SONAR_SCANNER_HOME}" != "" && "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
+if [ "${SONAR_SCANNER_HOME}" != "" ] && [ "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]
+then
     COMMAND="mvn verify -P jacoco sonar:sonar";
 # ELSE we cannot run Sonar analysis because the branch is coming
 # from a fork and Travis CI does not allow use to use encrypted variables.

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-COMMAND="mvn verify -P jacoco";
+# IF the variable is set, we can run Sonar analysis.
+# Indeed, that means that the build is performed on a branch of the
+# pitest/pitclipse repository and that Travis CI allows us to use
+# encrypted variables (e.g. Sonar's token)
+if [ "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
+    echo "Building main repository";
+    COMMAND="mvn verify -P jacoco sonar:sonar";
+# ELSE we cannot run Sonar analysis because the branch is coming
+# from a fork and Travis CI does not allow use to use encrypted variables.
+else
+    echo "Building a forked repository";
+    COMMAND="mvn verify -P jacoco";
+fi
 
 echo ${COMMAND}
 ${COMMAND}

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,7 +4,7 @@
 # Indeed, that means that the build is performed on a branch of the
 # pitest/pitclipse repository and that Travis CI allows us to use
 # encrypted variables (e.g. Sonar's token)
-if [ "$TRAVIS_SECURE_ENV_VARS" = true ]; then
+if [ "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
     echo "Building main repository";
     COMMAND="mvn verify -P jacoco sonar:sonar";
 # ELSE we cannot run Sonar analysis because the branch is coming

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-# IF the variable is set, we can run Sonar analysis.
+# IF the variables are set, we can run Sonar analysis.
 # Indeed, that means that the build is performed on a branch of the
-# pitest/pitclipse repository and that Travis CI allows us to use
+# pitest/pitclipse repository (or an internal PR) and that Travis CI allows us to use
 # encrypted variables (e.g. Sonar's token)
-if [ "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
-    echo "Building main repository";
+if [ "${SONAR_SCANNER_HOME}" != "" && "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
     COMMAND="mvn verify -P jacoco sonar:sonar";
 # ELSE we cannot run Sonar analysis because the branch is coming
 # from a fork and Travis CI does not allow use to use encrypted variables.
 else
-    echo "Building a forked repository";
     COMMAND="mvn verify -P jacoco";
 fi
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,12 +4,13 @@
 # Indeed, that means that the build is performed on a branch of the
 # pitest/pitclipse repository and that Travis CI allows us to use
 # encrypted variables (e.g. Sonar's token)
-if [ "${SONAR_SCANNER_HOME}" != "" ]; then
+if [ "$TRAVIS_SECURE_ENV_VARS" = true ]; then
+    echo "Building main repository";
     COMMAND="mvn verify -P jacoco sonar:sonar";
-
 # ELSE we cannot run Sonar analysis because the branch is coming
 # from a fork and Travis CI does not allow use to use encrypted variables.
 else
+    echo "Building a forked repository";
     COMMAND="mvn verify -P jacoco";
 fi
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 
-# IF the variable is set, we can run Sonar analysis.
-# Indeed, that means that the build is performed on a branch of the
-# pitest/pitclipse repository and that Travis CI allows us to use
-# encrypted variables (e.g. Sonar's token)
-if [ "${TRAVIS_REPO_SLUG}" = "pitest/pitclipse" ]; then
-    echo "Building main repository";
-    COMMAND="mvn verify -P jacoco sonar:sonar";
-# ELSE we cannot run Sonar analysis because the branch is coming
-# from a fork and Travis CI does not allow use to use encrypted variables.
-else
-    echo "Building a forked repository";
-    COMMAND="mvn verify -P jacoco";
-fi
+COMMAND="mvn verify -P jacoco";
 
 echo ${COMMAND}
 ${COMMAND}


### PR DESCRIPTION
without this change the build fails on Travis on forked repositories, because it still tries to perform SonarQube analysis, contacting SonarCloud.
In fact the variable SONAR_SCANNER_HOME is set also when building a fork.
Use ${TRAVIS_SECURE_ENV_VARS} instead

WARNING: @echebbi you should check that on the main repository SonarCloud analysis still works :)