### PR TITLE
Upgrade to Pitest 1.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- [#107](https://github.com/pitest/pitclipse/issues/107) Upgrade Pitest to 1.4.11
 
 ## [2.0.1] - 2020-02-06
 ### Added
@@ -20,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Pitclipse is now released at [https://dl.bintray.com/kazejiyu/Pitclipse/updates/](https://dl.bintray.com/kazejiyu/Pitclipse/updates/)
-- [#80](https://github.com/pitest/pitclipse/pull/80) Use Pitest 1.4.6
+- [#80](https://github.com/pitest/pitclipse/pull/80) Upgrade Pitest to 1.4.6
 - [#80](https://github.com/pitest/pitclipse/pull/80) Use Java 1.8
 
 ## [1.1.4] - 2016-04-19

--- a/bundles/org.pitest/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Pitest
 Bundle-SymbolicName: org.pitest
-Bundle-Version: 1.4.6
+Bundle-Version: 1.4.11
 Bundle-ClassPath: lib/pitest-command-line-javadoc.jar,
  lib/pitest-command-line-sources.jar,
  lib/pitest-command-line.jar,

--- a/bundles/org.pitest/pom.xml
+++ b/bundles/org.pitest/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>org.pitest</artifactId>
-	<version>1.4.6</version>
+	<version>1.4.11</version>
 	<packaging>eclipse-plugin</packaging>
 	<description>Wraps Pitest JAR as an Eclipse plug-in</description>
 
@@ -121,7 +121,7 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/SummaryResultListenerTestData.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/SummaryResultListenerTestData.java
@@ -26,6 +26,7 @@ import org.pitest.classinfo.ClassName;
 import org.pitest.coverage.ClassLine;
 import org.pitest.coverage.CoverageDatabase;
 import org.pitest.coverage.CoverageSummary;
+import org.pitest.coverage.InstructionLocation;
 import org.pitest.coverage.TestInfo;
 import org.pitest.mutationtest.ClassMutationResults;
 import org.pitest.mutationtest.DetectionStatus;
@@ -40,6 +41,7 @@ import org.pitest.pitclipse.runner.results.summary.SummaryResultListenerTestSuga
 
 import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.google.common.base.Predicates.notNull;
@@ -177,6 +179,11 @@ class SummaryResultListenerTestData {
                     return classInfo.get(input);
                 }
             };
+        }
+
+        @Override
+        public Collection<TestInfo> getTestsForInstructionLocation(InstructionLocation location) {
+            return Collections.emptyList();
         }
     }
 }

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j01_simple_project.feature
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j01_simple_project.feature
@@ -36,7 +36,7 @@ Feature: Code mutation analysis
     And the mutation results are
       | status      | project  | package | class       | line | mutation                                                     |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | replaced int return with 0 for foo/bar/Foo::doFoo            |
 
   Scenario: Create a bad test for doFoo
     Given the class FooTest in package foo.bar in project project1 is selected
@@ -46,7 +46,7 @@ Feature: Code mutation analysis
     And the mutation results are
       | status   | project  | package | class       | line | mutation                                                     |
       | SURVIVED | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
-      | SURVIVED | project1 | foo.bar | foo.bar.Foo |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | SURVIVED | project1 | foo.bar | foo.bar.Foo |    6 | replaced int return with 0 for foo/bar/Foo::doFoo           |
 
   Scenario: Create a better test for doFoo
     Given the class FooTest in package foo.bar in project project1 is selected
@@ -56,7 +56,7 @@ Feature: Code mutation analysis
     And the mutation results are
       | status | project  | package | class       | line | mutation                                                     |
       | KILLED | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
-      | KILLED | project1 | foo.bar | foo.bar.Foo |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | KILLED | project1 | foo.bar | foo.bar.Foo |    6 | replaced int return with 0 for foo/bar/Foo::doFoo           |
 
   Scenario: Run mutation tests at package, package root & project level
     When tests in package foo.bar are run for project project1
@@ -78,22 +78,22 @@ Feature: Code mutation analysis
 
   Scenario: Run the new test
     When test BarTest in package foo.bar is run for project project1
-    Then a coverage report is generated with 2 classes tested with overall coverage of 50% and mutation coverage of 50%
+    Then a coverage report is generated with 2 classes tested with overall coverage of 50% and mutation coverage of 25%
     And the mutation results are
       | status      | project  | package | class       | line | mutation                                                     |
+      | SURVIVED    | project1 | foo.bar | foo.bar.Bar |    6 | replaced int return with 0 for foo/bar/Bar::doBar            |
       | KILLED      | project1 | foo.bar | foo.bar.Bar |    6 | Replaced integer subtraction with addition                   |
-      | KILLED      | project1 | foo.bar | foo.bar.Bar |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |    6 | replaced int return with 0 for foo/bar/Foo::doFoo            |
     When tests in package foo.bar are run for project project1
-    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 100%
+    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 75%
     And the mutation results are
-      | status | project  | package | class       | line | mutation                                                     |
-      | KILLED | project1 | foo.bar | foo.bar.Bar |    6 | Replaced integer subtraction with addition                   |
-      | KILLED | project1 | foo.bar | foo.bar.Bar |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
-      | KILLED | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
-      | KILLED | project1 | foo.bar | foo.bar.Foo |    6 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | status   | project  | package | class       | line | mutation                                                     |
+      | SURVIVED | project1 | foo.bar | foo.bar.Bar |    6 | replaced int return with 0 for foo/bar/Bar::doBar            |
+      | KILLED   | project1 | foo.bar | foo.bar.Bar |    6 | Replaced integer subtraction with addition                   |
+      | KILLED   | project1 | foo.bar | foo.bar.Foo |    6 | Replaced integer addition with subtraction                   |
+      | KILLED   | project1 | foo.bar | foo.bar.Foo |    6 | replaced int return with 0 for foo/bar/Foo::doFoo            |
     When tests in source root src are run for project project1
-    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 100%
+    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 75%
     When tests are run for project project1
-    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 100%
+    Then a coverage report is generated with 2 classes tested with overall coverage of 100% and mutation coverage of 75%

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j02_tests_in_different_packages.feature
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j02_tests_in_different_packages.feature
@@ -30,16 +30,16 @@ Feature: Code mutation analysis in different packages
 
   Scenario: Run mutation testing at a package level
     When tests in package sea.fish are run for project project2
-    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 14%
+    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 17%
     When tests in package lake.fish are run for project project2
-    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 14%
+    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 17%
     When tests in package lake.amphibian are run for project project2
-    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 14%
+    Then a coverage report is generated with 4 classes tested with overall coverage of 25% and mutation coverage of 17%
 
   Scenario: Run mutation testing at a package root level
     When tests in source root src are run for project project2
-    Then a coverage report is generated with 4 classes tested with overall coverage of 100% and mutation coverage of 43%
+    Then a coverage report is generated with 4 classes tested with overall coverage of 100% and mutation coverage of 50%
 
   Scenario: Run mutation testing at a project level
     When tests are run for project project2
-    Then a coverage report is generated with 4 classes tested with overall coverage of 100% and mutation coverage of 43%
+    Then a coverage report is generated with 4 classes tested with overall coverage of 100% and mutation coverage of 50%

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j06_mutations_view.feature
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/j06_mutations_view.feature
@@ -14,13 +14,11 @@ Feature: Mutation view shows analysis results
     And the mutation results are
       | status      | project  | package | class       | line | mutation                                                     |
       | SURVIVED    | project1 | foo.bar | foo.bar.Bar |    9 | negated conditional                                          |
-      | SURVIVED    | project1 | foo.bar | foo.bar.Bar |   12 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
       | SURVIVED    | project1 | foo.bar | foo.bar.Foo |    9 | negated conditional                                          |
-      | SURVIVED    | project1 | foo.bar | foo.bar.Foo |   12 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | replaced int return with 0 for foo/bar/Bar::f                |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | replaced int return with 0 for foo/bar/Foo::f                |
 
   Scenario: Selecting a mutation opens the class in question at the right line number
     When the following mutation is selected
@@ -36,14 +34,12 @@ Feature: Mutation view shows analysis results
       | status      | project  | package | class       | line | mutation                                                     |
       | SURVIVED    | project1 | foo.bar | foo.bar.Bar |    9 | negated conditional                                          |
       | SURVIVED    | project1 | foo.bar | foo.bar.Bar |    9 | removed conditional - replaced equality check with false     |
-      | SURVIVED    | project1 | foo.bar | foo.bar.Bar |   12 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
       | SURVIVED    | project1 | foo.bar | foo.bar.Foo |    9 | negated conditional                                          |
       | SURVIVED    | project1 | foo.bar | foo.bar.Foo |    9 | removed conditional - replaced equality check with false     |
-      | SURVIVED    | project1 | foo.bar | foo.bar.Foo |   12 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Bar |   10 | replaced int return with 0 for foo/bar/Bar::f                |
       | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | Replaced integer addition with subtraction                   |
-      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | replaced return of integer sized value with (x == 0 ? 1 : 0) |
+      | NO_COVERAGE | project1 | foo.bar | foo.bar.Foo |   10 | replaced int return with 0 for foo/bar/Foo::f                |
 
   # This scenario does not pass anymore
   # This is likely due to the fact that Eclipse IDE creates new launch configuration


### PR DESCRIPTION
Broke some UI tests because outputs of Pitest have changed. I chose to trust Pitest's developers and updated the tests with the new values without deeper checks.

Changelog since 1.4.6:

1.4.11
 - Filter try-with-resources before filtering inlined code (thanks @Vampire)
 - Do not print the class name twice for unsplittable test units (thanks @Vampire)
 - Do not include the current directory to the minion class path (thanks @Vampire)
 - Add property='skipPitest' to skip attribute inn maven plugin (thanks @cjgwhite)
 - TestNG 7.0.0 compatibility (thanks @kris-scheibe)
 - UOI4 reports mutated field name (thanks @LaurentTho3)
 - Bump asm to 7.3.1
 - Use the new mutator set by default

1.4.10
 - Smaller blocks for more precise test targeting (thanks @jon-bell)
 - Fix A0D2 map key (thanks @Vampire)
 - Escape characters in init methods for html report (thanks @Vampire)
 - Filter junk mutations to compiler generated Objects.requireNonNull calls

1.4.9
 - Fix for powermock issues on (thanks @jon-bell)
 - Improved error message when no test plugin (thanks @szpak)
 - Support annotation processors such as Micronaut that do not set debug filename

1.4.8
 - Fix for bug in coverage when large number of classes (thanks @jon-bell)
 - Avoid stealing keyboard focus on macos (thanks @maxgabut)

1.4.7
 - Faster coverage calculation (thanks @jon-bell)