### PR TITLE
Prevent the dependencies of users' projects from messing up with Pitest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
+- [#74](https://github.com/pitest/pitclipse/issues/74) Prevent the dependencies of analyzed projects from messing up with Pitest
 - [#107](https://github.com/pitest/pitclipse/issues/107) Upgrade Pitest to 1.4.11
 
 ## [2.0.1] - 2020-02-06

--- a/bundles/org.pitest.pitclipse.launch/src/org/pitest/pitclipse/launch/AbstractPitLaunchDelegate.java
+++ b/bundles/org.pitest.pitclipse.launch/src/org/pitest/pitclipse/launch/AbstractPitLaunchDelegate.java
@@ -73,7 +73,8 @@ public abstract class AbstractPitLaunchDelegate extends JavaLaunchDelegate {
     @Override
     public String[] getClasspath(ILaunchConfiguration launchConfig) throws CoreException {
         List<String> newClasspath = ImmutableList.<String>builder()
-                .addAll(ImmutableList.copyOf(super.getClasspath(launchConfig))).addAll(getDefault().getPitClasspath())
+                .addAll(getDefault().getPitClasspath())
+                .addAll(ImmutableList.copyOf(super.getClasspath(launchConfig)))
                 .build();
         log("Classpath: " + newClasspath);
         return newClasspath.toArray(new String[newClasspath.size()]);


### PR DESCRIPTION
Closes #74 by putting Pitest's JARs first in the classpath, and project's dependencies second. I don't know exactly why it solves the issue, but according to my tests it works as expected.

**Important**: I'm going to merge this PR & release a new version so that users can test whether the fix works for them as well. If it does, we really need to **add a new test** where Pitest is run on a project that depends on ASM to prevent future regressions.

> Note: this solution has been inspired by [_this issue_](https://github.com/hcoles/pitest/issues/453) in Pitest's repository