### PR TITLE
Macos experiments

### DIFF
--- a/.github/workflows/windows-mac.yml
+++ b/.github/workflows/windows-mac.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/bundles/org.pitest.pitclipse.launch.ui/src/org/pitest/pitclipse/launch/ui/PitLaunchUiActivator.java
+++ b/bundles/org.pitest.pitclipse.launch.ui/src/org/pitest/pitclipse/launch/ui/PitLaunchUiActivator.java
@@ -19,6 +19,7 @@ package org.pitest.pitclipse.launch.ui;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -49,7 +50,7 @@ public class PitLaunchUiActivator extends AbstractUIPlugin {
         if (plugin == null) {
             return null;
         }
-        IWorkbench workBench = plugin.getWorkbench();
+        IWorkbench workBench = PlatformUI.getWorkbench();
         if (workBench == null) {
             return null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -117,17 +117,7 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
 							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86</arch>
 						</environment>
 						<environment>
 							<os>win32</os>

--- a/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
+++ b/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="org.pitest.pitclipse.target" sequenceNumber="6">
+<target name="org.pitest.pitclipse.target" sequenceNumber="7">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.e4.core.tools.feature.source.feature.group" version="0.0.0"/>
@@ -10,7 +10,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-06"/>
+			<repository location="https://download.eclipse.org/releases/2020-03"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="0.0.0"/>
@@ -53,7 +53,7 @@
 			<unit id="org.hamcrest.library.source" version="0.0.0"/>
 			<unit id="org.hamcrest.text" version="0.0.0"/>
 			<unit id="org.hamcrest.text.source" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-06/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-03/"/>
 		</location>
 	</locations>
 </target>

--- a/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
+++ b/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="org.pitest.pitclipse.target" sequenceNumber="3">
+<target name="org.pitest.pitclipse.target" sequenceNumber="6">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.e4.core.tools.feature.source.feature.group" version="0.0.0"/>
@@ -10,7 +10,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/photon"/>
+			<repository location="https://download.eclipse.org/releases/2020-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="0.0.0"/>
@@ -53,7 +53,7 @@
 			<unit id="org.hamcrest.library.source" version="0.0.0"/>
 			<unit id="org.hamcrest.text" version="0.0.0"/>
 			<unit id="org.hamcrest.text.source" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-06/"/>
 		</location>
 	</locations>
 </target>

--- a/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
+++ b/releng/org.pitest.pitclipse.target/org.pitest.pitclipse.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="org.pitest.pitclipse.target" sequenceNumber="7">
+<target name="org.pitest.pitclipse.target" sequenceNumber="6">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.e4.core.tools.feature.source.feature.group" version="0.0.0"/>
@@ -10,7 +10,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-03"/>
+			<repository location="https://download.eclipse.org/releases/2020-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="0.0.0"/>
@@ -53,7 +53,7 @@
 			<unit id="org.hamcrest.library.source" version="0.0.0"/>
 			<unit id="org.hamcrest.text" version="0.0.0"/>
 			<unit id="org.hamcrest.text.source" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-03/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-06/"/>
 		</location>
 	</locations>
 </target>

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/PitCliArgumentsTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/PitCliArgumentsTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.pitest.pitclipse.runner.config.PitConfiguration.DEFAULT_AVOID_CALLS_TO_LIST;
 

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/client/PitClientTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/client/PitClientTest.java
@@ -32,7 +32,7 @@ import org.pitest.pitclipse.runner.io.SocketProvider;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/config/PitConfigurationTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/config/PitConfigurationTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.pitest.pitclipse.runner.config.PitExecutionMode.PROJECT_ISOLATION;
 
 public class PitConfigurationTest {

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/ObjectStreamSocketTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/ObjectStreamSocketTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/SocketProviderIntegrationTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/SocketProviderIntegrationTest.java
@@ -27,7 +27,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.pitest.pitclipse.runner.io.SocketProviderIntegrationTestFixture.ECHO;
 import static org.pitest.pitclipse.runner.io.SocketProviderIntegrationTestFixture.ReturnStatus.SUCCESS;
 import static org.pitest.pitclipse.runner.io.SocketProviderIntegrationTestFixture.aFreePort;

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/model/ModelBuilderTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/model/ModelBuilderTest.java
@@ -45,7 +45,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.pitest.pitclipse.runner.results.DetectionStatus.KILLED;
 import static org.pitest.pitclipse.runner.results.DetectionStatus.SURVIVED;

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/mutations/MutationsResultListenerFactoryTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/mutations/MutationsResultListenerFactoryTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MutationsResultListenerFactoryTest {
 

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/SummaryResultListenerFactoryTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/SummaryResultListenerFactoryTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/Verification.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/results/summary/Verification.java
@@ -26,7 +26,7 @@ import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 class Verification {
     private final Optional<SummaryResult> actualResult;

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/server/PitServerTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/server/PitServerTest.java
@@ -30,7 +30,7 @@ import org.pitest.pitclipse.runner.io.SocketProvider;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/steps/PitclipseSteps.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/steps/PitclipseSteps.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.pitest.pitclipse.ui.behaviours.pageobjects.PageObjects.PAGES;
 import static org.pitest.pitclipse.ui.util.AssertUtil.assertDoubleEquals;
 


### PR DESCRIPTION
This fixes the problems we started to have on macOS GitHub Actions virtual environments.
It updates Eclipse TP to 2020-06 the last one NOT requiring Java 11. (I also fixed a few deprecated warnings)

@echebbi I really think that we should start building against the latest released Eclipse platform. That will require Java 11 but we already use Java 11 for SonarCloud. Moreover, it will NOT require Pitclipse users to use Java 11 anyway. This will also allow us to use Tycho more up-to-date versions, benefit from bug fixes and deal with problems we started to experience in the CI. I will create a separate issue for that.

@JKutscha when this gets merge please update your current working branches.