### PR TITLE
Resolved dependency clash

### DIFF
--- a/bundles/org.pitest.pitclipse.listeners/META-INF/MANIFEST.MF
+++ b/bundles/org.pitest.pitclipse.listeners/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-Version: 2.1.2.qualifier
 Fragment-Host: org.pitest;bundle-version="1.6.8"
 Automatic-Module-Name: org.pitest.pitclipse.listeners
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.pitest.pitclipse.runner;bundle-version="2.0.0"
 Bundle-ClassPath: .,
  META-INF/services/,
  src/
 Bundle-Vendor: Pitest.org
+Require-Bundle: org.pitest.pitclipse.runner

--- a/features/org.pitest.pitclipse.core.feature/feature.xml
+++ b/features/org.pitest.pitclipse.core.feature/feature.xml
@@ -228,6 +228,8 @@
    <requires>
       <import plugin="org.eclipse.core.runtime" version="3.11.1" match="compatible"/>
       <import plugin="org.eclipse.jdt.core" version="3.11.2" match="compatible"/>
+      <import plugin="org.pitest.pitclipse.runner" version="2.0.0" match="compatible"/>
+      <import plugin="org.pitest" version="1.6.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.10.1" match="compatible"/>
       <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
       <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>


### PR DESCRIPTION
Fix for #176.

Soloution: Remove `bundle-version="2.0.0"` from MANIFEST.MF because it caused an extra plug in import inside the feature.xml.