### PR TITLE
178: Change PIT timeout without altering SWTBot timeout during tests

### DIFF
--- a/tests/org.pitest.pitclipse.ui.tests/org.pitest.pitclipse.ui.tests.launch
+++ b/tests/org.pitest.pitclipse.ui.tests/org.pitest.pitclipse.ui.tests.launch
@@ -28,7 +28,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.pitest.pitclipse.ui.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dorg.eclipse.swtbot.search.timeout=20000"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Dorg.eclipse.swtbot.search.timeout=20000 -Dorg.pitest.pitclipse.tests.pit.timeout=10000"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <booleanAttribute key="show_selected_only" value="false"/>

--- a/tests/org.pitest.pitclipse.ui.tests/pom.xml
+++ b/tests/org.pitest.pitclipse.ui.tests/pom.xml
@@ -86,7 +86,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- Increase the timeout for SWTBot especially for the CI -->
-					<argLine>${additionalTestArgLine} ${os-jvm-flags} -Dorg.eclipse.swtbot.search.timeout=90000</argLine>
+					<argLine>${additionalTestArgLine} ${os-jvm-flags} -Dorg.eclipse.swtbot.search.timeout=90000 -Dorg.pitest.pitclipse.tests.pit.timeout=20000</argLine>
 				</configuration>
 			</plugin>
 			<!-- Explicit dependency to the listeners fragment: make Pitclipse's mutation 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/swtbot/PitResultNotifier.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/swtbot/PitResultNotifier.java
@@ -34,6 +34,8 @@ import org.pitest.pitclipse.ui.swtbot.ResultsParser.Summary;
 public class PitResultNotifier implements ResultNotifier<PitResults> {
     private static final String FAIL_MESSAGE = "Pit result was not ready for retrieval. Console output was: ";
 
+    private static long PIT_TIMEOUT = Long.valueOf(System.getProperty("org.pitest.pitclipse.tests.pit.timeout", "5000"));
+
     public enum PitSummary {
         INSTANCE;
         private Summary summary;
@@ -138,7 +140,7 @@ public class PitResultNotifier implements ResultNotifier<PitResults> {
                 public String getFailureMessage() {
                     return "No summary was generated after the specified time.";
                 }
-            }, (timeOut > 0) ? timeOut : SWTBotPreferences.TIMEOUT);
+            }, (timeOut > 0) ? timeOut : PIT_TIMEOUT);
         }
 
         private void setSummary(Summary summary) {


### PR DESCRIPTION
Task-Url: http://github.com/pitest/pitclipse/issues/178

Closes #178 