### PR TITLE
run menu and runconfigselector to function like the window menu

### DIFF
--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunConfigurationSelector.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunConfigurationSelector.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotRadio;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
@@ -300,6 +301,7 @@ public class RunConfigurationSelector implements Closeable {
             return;
         }
         shell.bot().button("Close").click();
+        bot.waitUntil(Conditions.shellCloses(shell));
     }
 
     /**

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunMenu.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/RunMenu.java
@@ -59,7 +59,9 @@ public class RunMenu {
     }
 
     public void runPitWithConfiguration(String configurationName) {
-        runConfigurationSelector.runWithConfigurationAndWaitForIt(configurationName);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.runWithConfigurationAndWaitForIt(configurationName);
+        }
     }
 
     /**
@@ -86,19 +88,31 @@ public class RunMenu {
     public List<PitRunConfiguration> runConfigurations() {
         SWTBotMenuHelper menuHelper = new SWTBotMenuHelper();
         menuHelper.findMenu(menuHelper.findWorkbenchMenu(bot, RUN), RUN_CONFIGURATIONS).click();
-        return runConfigurationSelector.getConfigurations();
+        return openRunMenu().andThen().getConfigurations();
     }
 
     public void createRunConfiguration(String configurationName, String projectName, String className) {
-        runConfigurationSelector.createRunConfiguration(configurationName, projectName, className);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.createRunConfiguration(configurationName, projectName, className);
+        }
     }
 
     public void setProjectForConfiguration(String configurationName, String project) {
-        runConfigurationSelector.setProjectForConfiguration(configurationName, project);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.setProjectForConfiguration(configurationName, project);
+        }
     }
 
     public void setTestClassForConfiguration(String configurationName, String testClass) {
-        runConfigurationSelector.setTestClassForConfiguration(configurationName, testClass);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.setTestClassForConfiguration(configurationName, testClass);
+        }
+    }
+
+    public void setTestDirForConfiguration(String configurationName, String testDir) {
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.setTestDirForConfiguration(configurationName, testDir);
+        }
     }
 
     public PitOptions getLastUsedPitOptions() {
@@ -111,7 +125,9 @@ public class RunMenu {
      * @param mutatorGroup      which group to select
      */
     public void setMutatorGroup(String configurationName, Mutators mutatorGroup) {
-        runConfigurationSelector.setMutatorGroup(configurationName, mutatorGroup);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.setMutatorGroup(configurationName, mutatorGroup);
+        }
     }
 
     /**
@@ -119,7 +135,9 @@ public class RunMenu {
      * @param configurationName of the configuration, where to select all mutators
      */
     public void checkAllMutators(String configurationName) {
-        runConfigurationSelector.checkAllMutators(configurationName);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.checkAllMutators(configurationName);
+        }
     }
 
     /**
@@ -128,7 +146,10 @@ public class RunMenu {
      * @param mutator           which should be toggled
      */
     public void toggleCustomMutator(String configurationName, Mutators mutator) {
-        runConfigurationSelector.toggleCustomMutator(configurationName, mutator);
+
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.toggleCustomMutator(configurationName, mutator);
+        }
     }
 
     /**
@@ -138,7 +159,9 @@ public class RunMenu {
      * @param mutator           which to select in the configuration
      */
     public void setOneCustomMutator(String configurationName, Mutators mutator) {
-        runConfigurationSelector.setOneCustomMutator(configurationName, mutator);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.setOneCustomMutator(configurationName, mutator);
+        }
     }
 
     /**
@@ -146,7 +169,22 @@ public class RunMenu {
      * @param configurationName which should be removed
      */
     public void removeConfig(String configurationName) {
-        runConfigurationSelector.removeConfig(configurationName);
+        try (RunConfigurationSelector selector = openRunMenu().andThen()) {
+            selector.removeConfig(configurationName);
+        }
     }
 
+    /**
+     * Opens the run menu and activates it
+     */
+    public RunConficurationDsl openRunMenu() {
+        runConfigurationSelector.openRunConfigurationShell();
+        return new RunConficurationDsl();
+    }
+
+    public class RunConficurationDsl {
+        public RunConfigurationSelector andThen() {
+            return runConfigurationSelector;
+        }
+    }
 }


### PR DESCRIPTION
I rewrote the run menu class and the run configuration selector to be more like the window menu class and that selector.
This allows to change more settings without opening the dialog multiple times and will always close the dialog, even if something went wrong.

Also, I am working on #164 and this change will allow easier tests.