### PR TITLE
Flaky UI tests

### DIFF
--- a/tests/org.pitest.pitclipse.ui.tests/pom.xml
+++ b/tests/org.pitest.pitclipse.ui.tests/pom.xml
@@ -86,7 +86,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<!-- Increase the timeout for SWTBot especially for the CI -->
-					<argLine>${additionalTestArgLine} ${os-jvm-flags} -Dorg.eclipse.swtbot.search.timeout=90000 -Dorg.pitest.pitclipse.tests.pit.timeout=20000</argLine>
+					<argLine>${additionalTestArgLine} ${os-jvm-flags} -Dorg.eclipse.swtbot.search.timeout=180000 -Dorg.pitest.pitclipse.tests.pit.timeout=20000</argLine>
 				</configuration>
 			</plugin>
 			<!-- Explicit dependency to the listeners fragment: make Pitclipse's mutation 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
@@ -16,6 +16,7 @@
 
 package org.pitest.pitclipse.ui.behaviours.pageobjects;
 
+import static org.pitest.pitclipse.ui.behaviours.pageobjects.PageObjects.PAGES;
 import static org.pitest.pitclipse.ui.behaviours.pageobjects.SwtBotTreeHelper.expand;
 
 import java.util.List;
@@ -60,6 +61,7 @@ public class PitMutationsViewPageObject {
     }
 
     public SWTBotView getView() {
+        PAGES.getConsole().close();
         SWTBotView mutationsView = bot.viewByTitle("PIT Mutations");
         mutationsView.show();
         mutationsView.setFocus();

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
@@ -62,6 +62,7 @@ public class PitMutationsViewPageObject {
     public SWTBotView getView() {
         SWTBotView mutationsView = bot.viewByTitle("PIT Mutations");
         mutationsView.show();
+        mutationsView.setFocus();
         // Make sure the 'PIT Mutations' view is opened
         bot.waitUntil(new ViewOpenedCondition(bot, "PIT Mutations"));
         return mutationsView;

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
@@ -66,7 +66,7 @@ public class PitMutationsViewPageObject {
         mutationsView.show();
         mutationsView.setFocus();
         // Make sure the 'PIT Mutations' view is opened
-        bot.waitUntil(new ViewOpenedCondition(bot, "PIT Mutations"));
+        // bot.waitUntil(new ViewOpenedCondition(bot, "PIT Mutations"));
         return mutationsView;
     }
 

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/PitMutationsViewPageObject.java
@@ -61,11 +61,14 @@ public class PitMutationsViewPageObject {
     }
 
     public SWTBotView getView() {
+        // let's close the Console view first, otherwise it seems
+        // to block the opening of "PIT Mutations"
         PAGES.getConsole().close();
         SWTBotView mutationsView = bot.viewByTitle("PIT Mutations");
         mutationsView.show();
         mutationsView.setFocus();
         // Make sure the 'PIT Mutations' view is opened
+        // this should not be required anymore
         // bot.waitUntil(new ViewOpenedCondition(bot, "PIT Mutations"));
         return mutationsView;
     }

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -1,6 +1,7 @@
 package org.pitest.pitclipse.ui.behaviours.pageobjects;
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 
 class ViewOpenedCondition extends DefaultCondition {
@@ -15,7 +16,13 @@ class ViewOpenedCondition extends DefaultCondition {
     
     @Override
     public boolean test() throws Exception {
-        return bot.viewByTitle(viewTitle) != null;
+        final SWTBotView view = bot.viewByTitle(viewTitle);
+        final boolean condition = view != null
+            && view.isActive();
+        if (!condition) {
+            System.out.println("*** " + viewTitle + " not yet active...");
+        }
+        return condition;
     }
     
     @Override

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -13,18 +13,22 @@ class ViewOpenedCondition extends DefaultCondition {
         this.bot = bot;
         this.viewTitle = viewTitle;
     }
-    
+
     @Override
     public boolean test() throws Exception {
         final SWTBotView view = bot.viewByTitle(viewTitle);
-        final boolean condition = view != null
-            && view.isActive();
-        if (!condition) {
-            System.out.println("*** " + viewTitle + " not yet active...");
+        boolean viewIsNotNull = view != null;
+        final boolean condition = viewIsNotNull
+                && view.isActive();
+        if (!viewIsNotNull) {
+            System.out.println("*** " + viewTitle + " null...");
+            if (viewIsNotNull && !condition) {
+                System.out.println("*** " + viewTitle + " not yet active...");
+            }
         }
         return condition;
     }
-    
+
     @Override
     public String getFailureMessage() {
         return "The view '" + viewTitle + "' did not open";

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -17,15 +17,7 @@ class ViewOpenedCondition extends DefaultCondition {
     @Override
     public boolean test() throws Exception {
         final SWTBotView view = bot.viewByTitle(viewTitle);
-        boolean viewIsNotNull = view != null;
-        final boolean condition = viewIsNotNull
-                && view.isActive();
-        if (!viewIsNotNull) {
-            System.out.println("*** " + viewTitle + " null...");
-        } else if (!condition) {
-            System.out.println("*** " + viewTitle + " not yet active...");
-        }
-        return condition;
+        return view.isActive();
     }
 
     @Override

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -1,7 +1,6 @@
 package org.pitest.pitclipse.ui.behaviours.pageobjects;
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
-import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 
 class ViewOpenedCondition extends DefaultCondition {
@@ -16,8 +15,7 @@ class ViewOpenedCondition extends DefaultCondition {
 
     @Override
     public boolean test() throws Exception {
-        final SWTBotView view = bot.viewByTitle(viewTitle);
-        return view.isActive();
+        return bot.viewByTitle(viewTitle).isActive();
     }
 
     @Override

--- a/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
+++ b/tests/org.pitest.pitclipse.ui.tests/src/org/pitest/pitclipse/ui/behaviours/pageobjects/ViewOpenedCondition.java
@@ -22,9 +22,8 @@ class ViewOpenedCondition extends DefaultCondition {
                 && view.isActive();
         if (!viewIsNotNull) {
             System.out.println("*** " + viewTitle + " null...");
-            if (viewIsNotNull && !condition) {
-                System.out.println("*** " + viewTitle + " not yet active...");
-            }
+        } else if (!condition) {
+            System.out.println("*** " + viewTitle + " not yet active...");
         }
         return condition;
     }


### PR DESCRIPTION
Investigate why org.pitest.pitclipse.ui.tests.PitclipsePitMutationsViewTest.expandAndCollapse() often fails on Windows and macOS (the failing screenshot shows that the required view is not active)