### PR TITLE
Java 17 and Tycho 4

### DIFF
--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -18,10 +18,11 @@ jobs:
       with:
         # Shallow clones should be disabled for a better relevancy of SonarQube analysis
         fetch-depth: 0
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3.6.0
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:

--- a/.github/workflows/maven-old-tp.yml
+++ b/.github/workflows/maven-old-tp.yml
@@ -25,6 +25,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
     - name: Install WebKit # required for SWT Browser
       run: |
         sudo apt update

--- a/.github/workflows/maven-old-tp.yml
+++ b/.github/workflows/maven-old-tp.yml
@@ -21,10 +21,11 @@ jobs:
       with:
         # Shallow clones should be disabled for a better relevancy of SonarQube analysis
         fetch-depth: 0
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3.6.0
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
     - name: Install WebKit # required for SWT Browser
       run: |
         sudo apt update

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,10 +19,11 @@ jobs:
       with:
         # Shallow clones should be disabled for a better relevancy of SonarQube analysis
         fetch-depth: 0
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3.6.0
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:

--- a/.github/workflows/windows-mac.yml
+++ b/.github/workflows/windows-mac.yml
@@ -21,10 +21,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3.6.0
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:

--- a/.github/workflows/windows-mac.yml
+++ b/.github/workflows/windows-mac.yml
@@ -25,6 +25,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <extensions>
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.6</version>
 	</extension>
 </extensions>

--- a/bundles/org.pitest.pitest-junit5-plugin/clean-copy-libs.launch
+++ b/bundles/org.pitest.pitest-junit5-plugin/clean-copy-libs.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
     <stringAttribute key="M2_GOALS" value="clean dependency:copy-dependencies@copy-libs -Dtycho.mode=maven"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
@@ -12,6 +13,10 @@
     <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:org.pitest.pitest-junit5-plugin}"/>
 </launchConfiguration>

--- a/bundles/org.pitest/clean-copy-libs.launch
+++ b/bundles/org.pitest/clean-copy-libs.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
     <stringAttribute key="M2_GOALS" value="clean dependency:copy-dependencies@copy-libs -Dtycho.mode=maven"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
@@ -12,6 +13,10 @@
     <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:org.pitest}"/>
 </launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
 	<properties>
 		<!-- PLUGIN DEPENDENCIES -->
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 		<jacoco-version>0.8.6</jacoco-version>
 
 		<!-- MISC -->

--- a/releng/org.pitest.pitclipse.target/older.target
+++ b/releng/org.pitest.pitclipse.target/older.target
@@ -10,7 +10,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/photon"/>
+			<repository location="https://download.eclipse.org/releases/2018-09"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.pitest.pitclipse.target/older.target
+++ b/releng/org.pitest.pitclipse.target/older.target
@@ -10,7 +10,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2018-09"/>
+			<repository location="https://download.eclipse.org/releases/2021-12"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.google.guava" version="0.0.0"/>

--- a/tests/org.pitest.pitclipse.runner.tests/org.pitest.pitclipse.runner.tests.launch
+++ b/tests/org.pitest.pitclipse.runner.tests/org.pitest.pitclipse.runner.tests.launch
@@ -14,6 +14,7 @@
     <booleanAttribute key="default" value="true"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/org.pitest.pitclipse.runner.tests"/>
     </listAttribute>
@@ -24,7 +25,9 @@
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.pitest.pitclipse.runner.tests"/>

--- a/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/ObjectStreamSocketTest.java
+++ b/tests/org.pitest.pitclipse.runner.tests/src/org/pitest/pitclipse/runner/io/ObjectStreamSocketTest.java
@@ -16,22 +16,6 @@
 
 package org.pitest.pitclipse.runner.io;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.net.Socket;
-
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 import static org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -43,9 +27,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.net.Socket;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ObjectStreamSocketTest {
@@ -121,7 +120,7 @@ public class ObjectStreamSocketTest {
 
     @Test
     public void readThrowsException() throws IOException, ClassNotFoundException {
-        InputStream inputStream = spy(new ByteArrayInputStream(asBytes(expectedObject)));
+        InputStream inputStream = new ByteArrayInputStream(asBytes(expectedObject));
         OutputStream outputStream = new ByteArrayOutputStream();
         when(underlyingSocket.getInputStream()).thenReturn(inputStream);
         when(underlyingSocket.getOutputStream()).thenReturn(outputStream);
@@ -138,7 +137,7 @@ public class ObjectStreamSocketTest {
 
     @Test
     public void writeThrowsException() throws IOException, ClassNotFoundException {
-        InputStream inputStream = spy(new ByteArrayInputStream(asBytes(expectedObject)));
+        InputStream inputStream = new ByteArrayInputStream(asBytes(expectedObject));
         OutputStream outputStream = new ByteArrayOutputStream();
         when(underlyingSocket.getInputStream()).thenReturn(inputStream);
         when(underlyingSocket.getOutputStream()).thenReturn(outputStream);


### PR DESCRIPTION
Closes #225
Closes #215 

Note that the older target has been upgraded to 2021-12 which is the first Eclipse version support Java 17. Photon is way too old and UI tests fail for JUnit 5 (it's useless trying to build with such an ancient version).

This PR also uses the new version of `setup-java` action.